### PR TITLE
feat: make it possilbe to set images in parent chart

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,6 +85,10 @@ jobs:
           ztunnel_image: ${ZTUNNEL_IMAGE}
           EOF
 
+      - name: Inject tweak templates into subchart packages
+        run: |
+          bash tweak/tweak.sh
+
       - name: Upload helm-templates artifact
         uses: actions/upload-artifact@v7
         with:

--- a/helm-templates/qubership-istio/templates/_tweak.tpl
+++ b/helm-templates/qubership-istio/templates/_tweak.tpl
@@ -1,0 +1,12 @@
+{{- /*
+  Stub definitions for the custom image templates used by subchart tweak files.
+  These return empty strings so that standalone helm template / helm lint passes
+  without errors. The real implementations are expected to be provided by a
+  higher-level parent chart that overrides these definitions at deploy time.
+*/ -}}
+
+{{- define "custom.cni.image" -}}{{- end -}}
+
+{{- define "custom.istiod.image" -}}{{- end -}}
+
+{{- define "custom.ztunnel.image" -}}{{- end -}}

--- a/tweak/cni/zzzz_tweak.yaml
+++ b/tweak/cni/zzzz_tweak.yaml
@@ -1,0 +1,10 @@
+{{- /*
+  Overrides the image value using a template defined in the parent chart.
+  This is necessary when the current chart is included as a subchart — the real
+  image value cannot be known statically and must be calculated at deploy time
+  by the parent chart's template logic.
+*/ -}}
+{{- $customImage := include "custom.cni.image" . -}}
+{{- if $customImage -}}
+{{- $_ := set .Values "image" $customImage -}}
+{{- end -}}

--- a/tweak/istiod/zzzz_tweak.yaml
+++ b/tweak/istiod/zzzz_tweak.yaml
@@ -1,0 +1,10 @@
+{{- /*
+  Overrides the image value using a template defined in the parent chart.
+  This is necessary when the current chart is included as a subchart — the real
+  image value cannot be known statically and must be calculated at deploy time
+  by the parent chart's template logic.
+*/ -}}
+{{- $customImage := include "custom.istiod.image" . -}}
+{{- if $customImage -}}
+{{- $_ := set .Values "image" $customImage -}}
+{{- end -}}

--- a/tweak/tweak.sh
+++ b/tweak/tweak.sh
@@ -1,0 +1,12 @@
+# injects tweak templates into subchart packages
+# to allow custom image overrides in the parent chart
+# zzzz prefix in name is used to ensure the tweak template is loaded last
+# even after istio zzz_profile.yaml is processed
+CHARTS_DIR=./helm-templates/qubership-istio/charts
+for chart in cni istiod ztunnel; do
+TGZ=$(ls ${CHARTS_DIR}/${chart}-*.tgz)
+tar -xzf "${TGZ}" -C "${CHARTS_DIR}"
+cp tweak/${chart}/zzzz_tweak.yaml "${CHARTS_DIR}/${chart}/templates/"
+tar -czf "${TGZ}" -C "${CHARTS_DIR}" "${chart}"
+rm -rf "${CHARTS_DIR}/${chart}"
+done

--- a/tweak/ztunnel/zzzz_tweak.yaml
+++ b/tweak/ztunnel/zzzz_tweak.yaml
@@ -1,0 +1,10 @@
+{{- /*
+  Overrides the image value using a template defined in the parent chart.
+  This is necessary when the current chart is included as a subchart — the real
+  image value cannot be known statically and must be calculated at deploy time
+  by the parent chart's template logic.
+*/ -}}
+{{- $customImage := include "custom.ztunnel.image" . -}}
+{{- if $customImage -}}
+{{- $_ := set .Values "image" $customImage -}}
+{{- end -}}


### PR DESCRIPTION
Case: qubership-istio will be included as subchart to another chart 
Requirement: make it possible to override images used by istio componets with minimal original istio charts changes
Idea: to define templates, that can be overriden in parent chart, use templates to tweak .Values.image values during original istio charts rendering. 