### PR TITLE
fix: update istiod webhook RBAC configuration for namespace handling

### DIFF
--- a/tests/istiod-rbac/test.sh
+++ b/tests/istiod-rbac/test.sh
@@ -35,7 +35,10 @@ assert_cannot() {
 # 1. Webhooks: write verbs only on istiod's own webhook configs (resourceNames),
 #    collection verbs (list/watch) remain cluster-wide.
 # ---------------------------------------------------------------------------
-INJECTOR="istio-sidecar-injector-${ISTIO_NAMESPACE}"
+# istio omits the namespace suffix from the injector webhook name in istio-system;
+# the validator always carries it.
+INJECTOR="istio-sidecar-injector"
+[ "${ISTIO_NAMESPACE}" = "istio-system" ] || INJECTOR="istio-sidecar-injector-${ISTIO_NAMESPACE}"
 VALIDATOR="istio-validator-${ISTIO_NAMESPACE}"
 
 assert_can    update "mutatingwebhookconfigurations/${INJECTOR}"

--- a/tweak/istiod-rbac/istiod-webhook-rbac.yaml
+++ b/tweak/istiod-rbac/istiod-webhook-rbac.yaml
@@ -1,14 +1,15 @@
 {{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{- $rev := "" }}{{- if not (eq .Values.revision "") }}{{- $rev = printf "-%s" .Values.revision }}{{- end }}
-{{- $ns := .Release.Namespace }}
-{{- $mwcNames := list (printf "istio-sidecar-injector%s-%s" $rev $ns) }}
-{{- range $tag := (default (list) .Values.revisionTags) }}{{- $mwcNames = append $mwcNames (printf "istio-revision-tag-%s-%s" $tag $ns) }}{{- end }}
+{{- /* istio omits the namespace suffix from webhook names when installed in istio-system */}}
+{{- $ns := "" }}{{- if not (eq .Release.Namespace "istio-system") }}{{- $ns = printf "-%s" .Release.Namespace }}{{- end }}
+{{- $mwcNames := list (printf "istio-sidecar-injector%s%s" $rev $ns) }}
+{{- range $tag := (default (list) .Values.revisionTags) }}{{- $mwcNames = append $mwcNames (printf "istio-revision-tag-%s%s" $tag $ns) }}{{- end }}
 {{- $vwcNames := list "istiod-default-validator" (printf "istio-validator%s-%s" $rev .Values.global.istioNamespace) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-webhook-rbac{{ $rev }}-{{ $ns }}
+  name: istiod-webhook-rbac{{ $rev }}{{ $ns }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -39,7 +40,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-webhook-rbac{{ $rev }}-{{ $ns }}
+  name: istiod-webhook-rbac{{ $rev }}{{ $ns }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -48,7 +49,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-webhook-rbac{{ $rev }}-{{ $ns }}
+  name: istiod-webhook-rbac{{ $rev }}{{ $ns }}
 subjects:
   - kind: ServiceAccount
     name: istiod{{ $rev }}


### PR DESCRIPTION
- Adjusted the injector webhook name to omit the namespace suffix when installed in istio-system.
- Updated the RBAC YAML to reflect the new naming convention for the webhook resources, ensuring consistency across configurations.