### PR TITLE
fix: add istio-cni-node PodMonitor and complete the Istio dashboards

### DIFF
--- a/helm-templates/qubership-istio/dashboards/istio-control-plane-dashboard.json
+++ b/helm-templates/qubership-istio/dashboards/istio-control-plane-dashboard.json
@@ -87,7 +87,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (tag) (istio_build{component=\"pilot\"})",
+          "expr": "sum by (tag) (istio_build{cluster=~\"$cluster\", component=\"pilot\"})",
           "legendFormat": "Version ({{tag}})"
         }
       ],
@@ -172,7 +172,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (container_memory_working_set_bytes{container=\"discovery\",pod=~\"istiod-.*\"})",
+          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", container=\"discovery\",pod=~\"istiod-.*\"})",
           "legendFormat": "Container ({{pod}})"
         },
         {
@@ -180,7 +180,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (go_memstats_stack_inuse_bytes{app=\"istiod\"})",
+          "expr": "sum by (pod) (go_memstats_stack_inuse_bytes{cluster=~\"$cluster\", app=\"istiod\"})",
           "legendFormat": "Stack ({{pod}})"
         },
         {
@@ -188,7 +188,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (go_memstats_heap_inuse_bytes{app=\"istiod\"})",
+          "expr": "sum by (pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", app=\"istiod\"})",
           "legendFormat": "Heap (In Use) ({{pod}})"
         },
         {
@@ -196,7 +196,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (go_memstats_heap_alloc_bytes{app=\"istiod\"})",
+          "expr": "sum by (pod) (go_memstats_heap_alloc_bytes{cluster=~\"$cluster\", app=\"istiod\"})",
           "legendFormat": "Heap (Allocated) ({{pod}})"
         },
         {
@@ -205,7 +205,7 @@
             "uid": "$datasource"
           },
           "alias": "limit",
-          "expr": "kube_pod_container_resource_limits{container=\"discovery\",pod=~\"istiod-.*\",resource=\"memory\"}",
+          "expr": "kube_pod_container_resource_limits{cluster=~\"$cluster\", container=\"discovery\",pod=~\"istiod-.*\",resource=\"memory\"}",
           "legendFormat": "Memory Limit ({{pod}})",
           "refId": "F"
         }
@@ -271,7 +271,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (rate(go_memstats_alloc_bytes_total{app=\"istiod\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (rate(go_memstats_alloc_bytes_total{cluster=~\"$cluster\", app=\"istiod\"}[$__rate_interval]))",
           "legendFormat": "Bytes ({{pod}})"
         },
         {
@@ -279,7 +279,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (rate(go_memstats_mallocs_total{app=\"istiod\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (rate(go_memstats_mallocs_total{cluster=~\"$cluster\", app=\"istiod\"}[$__rate_interval]))",
           "legendFormat": "Objects ({{pod}})"
         }
       ],
@@ -350,7 +350,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (irate(container_cpu_usage_seconds_total{container=\"discovery\",pod=~\"istiod-.*\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (irate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", container=\"discovery\",pod=~\"istiod-.*\"}[$__rate_interval]))",
           "legendFormat": "Container ({{pod}})"
         },
         {
@@ -359,7 +359,7 @@
             "uid": "$datasource"
           },
           "alias": "limit",
-          "expr": "kube_pod_container_resource_limits{container=\"discovery\",pod=~\"istiod-.*\",resource=\"cpu\"}",
+          "expr": "kube_pod_container_resource_limits{cluster=~\"$cluster\", container=\"discovery\",pod=~\"istiod-.*\",resource=\"cpu\"}",
           "legendFormat": "CPU Limit ({{pod}})",
           "refId": "B"
         }
@@ -406,7 +406,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (go_goroutines{app=\"istiod\"})",
+          "expr": "sum by (pod) (go_goroutines{cluster=~\"$cluster\", app=\"istiod\"})",
           "legendFormat": "Goroutines ({{pod}})"
         }
       ],
@@ -600,7 +600,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (type) (irate(pilot_xds_pushes[$__rate_interval]))",
+          "expr": "sum by (type) (irate(pilot_xds_pushes{cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{type}}"
         }
       ],
@@ -647,7 +647,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (type,event) (rate(pilot_k8s_reg_events[$__rate_interval]))",
+          "expr": "sum by (type,event) (rate(pilot_k8s_reg_events{cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{event}} {{type}}"
         },
         {
@@ -655,7 +655,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (type,event) (rate(pilot_k8s_cfg_events[$__rate_interval]))",
+          "expr": "sum by (type,event) (rate(pilot_k8s_cfg_events{cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{event}} {{type}}"
         },
         {
@@ -663,7 +663,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (type) (rate(pilot_push_triggers[$__rate_interval]))",
+          "expr": "sum by (type) (rate(pilot_push_triggers{cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Push {{type}}"
         }
       ],
@@ -709,7 +709,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(envoy_cluster_upstream_cx_active{cluster_name=\"xds-grpc\"})",
+          "expr": "sum(envoy_cluster_upstream_cx_active{cluster=~\"$cluster\", cluster_name=\"xds-grpc\"})",
           "legendFormat": "Connections (client reported)"
         },
         {
@@ -717,7 +717,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum (pilot_xds)",
+          "expr": "sum (pilot_xds{cluster=~\"$cluster\"})",
           "legendFormat": "Connections (server reported)"
         }
       ],
@@ -763,7 +763,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (type) (pilot_total_xds_rejects)",
+          "expr": "sum by (type) (pilot_total_xds_rejects{cluster=~\"$cluster\"})",
           "legendFormat": "Rejected Config ({{type}})"
         },
         {
@@ -771,7 +771,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "pilot_total_xds_internal_errors",
+          "expr": "pilot_total_xds_internal_errors{cluster=~\"$cluster\"}",
           "legendFormat": "Internal Errors"
         }
       ],
@@ -817,7 +817,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(rate(pilot_xds_push_time_bucket{}[$__rate_interval])) by (le)",
+          "expr": "sum(rate(pilot_xds_push_time_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
           "legendFormat": "{{le}}"
         }
@@ -864,7 +864,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(rate(pilot_xds_config_size_bytes_bucket{}[$__rate_interval])) by (le)",
+          "expr": "sum(rate(pilot_xds_config_size_bytes_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
           "legendFormat": "{{le}}"
         }
@@ -921,7 +921,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum (rate(galley_validation_passed[$__rate_interval]))",
+          "expr": "sum (rate(galley_validation_passed{cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Success"
         },
         {
@@ -929,7 +929,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum (rate(galley_validation_failed[$__rate_interval]))",
+          "expr": "sum (rate(galley_validation_failed{cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Failure"
         }
       ],
@@ -972,7 +972,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum (rate(sidecar_injection_success_total[$__rate_interval]))",
+          "expr": "sum (rate(sidecar_injection_success_total{cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Success"
         },
         {
@@ -980,7 +980,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum (rate(sidecar_injection_failure_total[$__rate_interval]))",
+          "expr": "sum (rate(sidecar_injection_failure_total{cluster=~\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "Failure"
         }
       ],
@@ -996,6 +996,25 @@
         "name": "datasource",
         "query": "prometheus",
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "includeAll": true,
+        "label": "cluster",
+        "name": "cluster",
+        "query": "label_values(cluster)",
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },

--- a/helm-templates/qubership-istio/dashboards/istio-control-plane-dashboard.json
+++ b/helm-templates/qubership-istio/dashboards/istio-control-plane-dashboard.json
@@ -325,7 +325,6 @@
             ]
           }
         ]
-
       },
       "gridPos": {
         "h": 10,
@@ -606,7 +605,8 @@
         }
       ],
       "title": "XDS Pushes",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Rate of configuration pushes sent by Pilot to the data plane, by resource type"
     },
     {
       "datasource": {
@@ -1006,5 +1006,8 @@
   "timezone": "utc",
   "title": "Istio Control Plane Dashboard",
   "uid": "1813f692a8e4ac77155348d4c7d2fba8",
-  "gnetId": 7645
+  "gnetId": 7645,
+  "tags": [
+    "istio"
+  ]
 }

--- a/helm-templates/qubership-istio/dashboards/istio-ztunnel-dashboard.json
+++ b/helm-templates/qubership-istio/dashboards/istio-ztunnel-dashboard.json
@@ -90,7 +90,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (tag) (istio_build{component=\"ztunnel\"})",
+          "expr": "sum by (tag) (istio_build{cluster=~\"$cluster\", component=\"ztunnel\"})",
           "legendFormat": "Version ({{tag}})"
         }
       ],
@@ -162,7 +162,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (container_memory_working_set_bytes{container=\"istio-proxy\",pod=~\"ztunnel-.*\"})",
+          "expr": "sum by (pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", container=\"istio-proxy\",pod=~\"ztunnel-.*\"})",
           "legendFormat": "Container ({{pod}})"
         },
         {
@@ -171,7 +171,7 @@
             "uid": "$datasource"
           },
           "alias": "limit",
-          "expr": "kube_pod_container_resource_limits{container=\"istio-proxy\",pod=~\"ztunnel-.*\",resource=\"memory\"}",
+          "expr": "kube_pod_container_resource_limits{cluster=~\"$cluster\", container=\"istio-proxy\",pod=~\"ztunnel-.*\",resource=\"memory\"}",
           "legendFormat": "Memory Limit ({{pod}})",
           "refId": "F"
         }
@@ -243,7 +243,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (irate(container_cpu_usage_seconds_total{container=\"istio-proxy\",pod=~\"ztunnel-.*\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (irate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", container=\"istio-proxy\",pod=~\"ztunnel-.*\"}[$__rate_interval]))",
           "legendFormat": "Container ({{pod}})"
         },
         {
@@ -252,7 +252,7 @@
             "uid": "$datasource"
           },
           "alias": "limit",
-          "expr": "kube_pod_container_resource_limits{container=\"istio-proxy\",pod=~\"ztunnel-.*\",resource=\"cpu\"}",
+          "expr": "kube_pod_container_resource_limits{cluster=~\"$cluster\", container=\"istio-proxy\",pod=~\"ztunnel-.*\",resource=\"cpu\"}",
           "legendFormat": "CPU Limit ({{pod}})",
           "refId": "B"
         }
@@ -313,7 +313,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (rate(istio_tcp_connections_opened_total{pod=~\"ztunnel-.*\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (rate(istio_tcp_connections_opened_total{cluster=~\"$cluster\", pod=~\"ztunnel-.*\"}[$__rate_interval]))",
           "legendFormat": "Opened ({{pod}})"
         },
         {
@@ -321,7 +321,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "-sum by (pod) (rate(istio_tcp_connections_closed_total{pod=~\"ztunnel-.*\"}[$__rate_interval]))",
+          "expr": "-sum by (pod) (rate(istio_tcp_connections_closed_total{cluster=~\"$cluster\", pod=~\"ztunnel-.*\"}[$__rate_interval]))",
           "legendFormat": "Closed ({{pod}})"
         }
       ],
@@ -368,7 +368,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (rate(istio_tcp_sent_bytes_total{pod=~\"ztunnel-.*\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (rate(istio_tcp_sent_bytes_total{cluster=~\"$cluster\", pod=~\"ztunnel-.*\"}[$__rate_interval]))",
           "legendFormat": "Sent ({{pod}})"
         },
         {
@@ -376,7 +376,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (rate(istio_tcp_received_bytes_total{pod=~\"ztunnel-.*\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (rate(istio_tcp_received_bytes_total{cluster=~\"$cluster\", pod=~\"ztunnel-.*\"}[$__rate_interval]))",
           "legendFormat": "Received ({{pod}})"
         }
       ],
@@ -423,7 +423,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (rate(istio_dns_requests_total{pod=~\"ztunnel-.*\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (rate(istio_dns_requests_total{cluster=~\"$cluster\", pod=~\"ztunnel-.*\"}[$__rate_interval]))",
           "legendFormat": "Request ({{pod}})"
         }
       ],
@@ -482,7 +482,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (rate(istio_xds_connection_terminations_total{pod=~\"ztunnel-.*\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (rate(istio_xds_connection_terminations_total{cluster=~\"$cluster\", pod=~\"ztunnel-.*\"}[$__rate_interval]))",
           "legendFormat": "XDS Connection Terminations ({{pod}})"
         }
       ],
@@ -663,7 +663,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (url) (irate(istio_xds_message_total{pod=~\"ztunnel-.*\"}[$__rate_interval]))",
+          "expr": "sum by (url) (irate(istio_xds_message_total{cluster=~\"$cluster\", pod=~\"ztunnel-.*\"}[$__rate_interval]))",
           "legendFormat": "{{url}}"
         }
       ],
@@ -710,7 +710,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (workload_manager_active_proxy_count{pod=~\"ztunnel-.*\"})",
+          "expr": "sum by (pod) (workload_manager_active_proxy_count{cluster=~\"$cluster\", pod=~\"ztunnel-.*\"})",
           "legendFormat": "Active Proxies ({{pod}})"
         },
         {
@@ -718,7 +718,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum by (pod) (workload_manager_pending_proxy_count{pod=~\"ztunnel-.*\"})",
+          "expr": "sum by (pod) (workload_manager_pending_proxy_count{cluster=~\"$cluster\", pod=~\"ztunnel-.*\"})",
           "legendFormat": "Pending Proxies ({{pod}})"
         }
       ],
@@ -734,6 +734,25 @@
         "name": "datasource",
         "query": "prometheus",
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "includeAll": true,
+        "label": "cluster",
+        "name": "cluster",
+        "query": "label_values(cluster)",
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },

--- a/helm-templates/qubership-istio/dashboards/istio-ztunnel-dashboard.json
+++ b/helm-templates/qubership-istio/dashboards/istio-ztunnel-dashboard.json
@@ -137,7 +137,6 @@
             ]
           }
         ]
-
       },
       "gridPos": {
         "h": 8,
@@ -219,7 +218,6 @@
             ]
           }
         ]
-
       },
       "gridPos": {
         "h": 8,
@@ -670,7 +668,8 @@
         }
       ],
       "title": "XDS Pushes",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Rate of XDS messages exchanged with the control plane, by message type"
     },
     {
       "datasource": {
@@ -745,5 +744,8 @@
   "timezone": "utc",
   "title": "Istio Ztunnel Dashboard",
   "uid": "12c58766acc81a1c835dd5059eaf2741",
-  "gnetId": 21306
+  "gnetId": 21306,
+  "tags": [
+    "istio"
+  ]
 }

--- a/helm-templates/qubership-istio/templates/PodMonitor.yaml
+++ b/helm-templates/qubership-istio/templates/PodMonitor.yaml
@@ -12,4 +12,17 @@ spec:
   selector:
     matchLabels:
       app: ztunnel
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: istio-cni-node-monitor
+spec:
+  podMetricsEndpoints:
+    - interval: {{ .Values.monitoring.scrapeInterval }}
+      path: /metrics
+      port: metrics
+  selector:
+    matchLabels:
+      k8s-app: istio-cni-node
   {{- end }}


### PR DESCRIPTION
## What does this PR do?

Closes three gaps found while reviewing the monitoring resources and dashboards this chart ships.

**1. `istio-cni-node` metrics were never scraped.** The chart shipped a `PodMonitor` for ztunnel and a `ServiceMonitor` for istiod, but nothing for the `istio-cni-node` daemonset. Its pods already expose metrics on a container port named `metrics` and carry the label `k8s-app: istio-cni-node`, so only the resource was missing.

- `helm-templates/qubership-istio/templates/PodMonitor.yaml`: adds `istio-cni-node-monitor` alongside the existing `ztunnel-monitor`, inside the same `MONITORING_ENABLED` guard.

**2. Dashboard metadata was incomplete.** Neither dashboard had a `tags` key, so the Tags column in the Grafana folder was empty and neither could be filtered by tag. `XDS Pushes` was also the only panel on either dashboard without a `description`, so Grafana drew no info icon for it while every neighbouring panel had one.

- both files under `helm-templates/qubership-istio/dashboards/`: adds `tags: ["istio"]` and fills in the `XDS Pushes` description.

**3. Dashboards could not distinguish clusters.** Both had only a `datasource` variable. Against a datasource that fans out to several clusters, such as Promxy, every panel mixed all of them together with no way to narrow down.

- both dashboard files: adds a `cluster` template variable and constrains all queries with `cluster=~"$cluster"` (25 queries on the control plane dashboard, 14 on the ztunnel one).

The variable defaults to All with an `allValue` of `.*`. A regex matcher in PromQL also matches series that carry no `cluster` label at all, so a single-cluster installation renders exactly as it did before. This was measured rather than assumed, see below.

One thing worth a reviewer's attention: a few Istio metrics carry a `cluster` label of their own, `controller_sync_errors_total` from istio-cni being one. None of the eight metrics these panels actually query does, which was checked one by one against a live backend, so the current panels cannot clash. A panel built later on istio-cni metrics could, and in that case naming the variable after the datasource's own label would avoid it.

## Why

The monitoring resources and dashboards were added recently and these gaps showed up on first real use: one daemonset producing no metrics, dashboards that could not be tagged or filtered by cluster, and one panel missing its description.

## How was it tested?

**All 39 modified queries were executed against a live Prometheus-compatible backend**, not just rendered. The check was not only that each query parses, but that it returns the *same number of series* as the original:

```
total: 39 succeeded, 0 failed
```

No query changed its series count, which confirms the added matcher filters nothing out where the `cluster` label is absent. This also catches malformed PromQL, since a broken selector would either fail to parse or return a different number of series.

This mattered: the first version of the change was wrong. The transformation treated `sum` as a metric name and produced `sum{cluster=~"$cluster"} by (tag) (...)`, which is invalid PromQL. Helm renders that happily, since to Helm it is just a string inside a JSON file. It was caught by reading all 39 expressions and then running them.

**Both charts render.** Fetching the subcharts was needed first; the downloaded `charts/` and `Chart.lock` are not part of this PR.

```
$ helm template istio helm-templates/qubership-istio -s templates/PodMonitor.yaml
kind: PodMonitor  name: ztunnel-monitor          (unchanged)
kind: PodMonitor  name: istio-cni-node-monitor   port: metrics  k8s-app: istio-cni-node
```

Parsing the dashboard JSON back out of the rendered `Dashboard.yaml`:

| Dashboard | tags | time | templating | panels without description |
|---|---|---|---|---|
| Control Plane | `['istio']` | `now-30m` | `datasource`, `cluster` | none |
| Ztunnel | `['istio']` | `now-30m` | `datasource`, `cluster` | none |

**Semantic diff of the parsed JSON**, to make sure rewriting whole files introduced nothing accidental:

```
istio-control-plane-dashboard: 28 changes - 25 queries, description, templating, tags
istio-ztunnel-dashboard:       17 changes - 14 queries, description, templating, tags
```

Nothing else moved: `time`, `uid`, `schemaVersion` and panel order are untouched.

**The daemonset was checked on a live cluster**: its pods carry `k8s-app: istio-cni-node`, expose a container port named `metrics`, and reading that endpoint returned Prometheus output, so the new `PodMonitor` selects something real.

Verified after rollout on a live cluster: the new monitor produces one scrape target per node with `up=1`, where before the change no such target existed at all. Both dashboards were read back from the deployed objects and carry the tags, the panel description and the `cluster` variable.

Still not verified: the behaviour of the `cluster` variable against a genuinely multi-cluster datasource. No cluster available for testing sets external labels, so only the no-label case could be measured.


## Related

- _none_

