### PR TITLE
feat: patch pss

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -97,10 +97,13 @@ jobs:
             require_dual_stack: "true"
           # General functional tests (not IP-family specific), on a plain
           # single-stack IPv4 cluster — kept separate from the dual-stack tests.
+          # patch-pss runs last: it temporarily stages enforce=restricted on
+          # istio-system and leaves ENABLE_PRIVILEGED_PSS=true sticky on the
+          # release, so nothing after it could be affected.
           - name: functional
             ip_family: ipv4
             kind_config: tests/kind-ipv4.yaml
-            tests: gateway num-trusted-proxies rollout istiod-rbac
+            tests: gateway num-trusted-proxies rollout istiod-rbac patch-pss
             require_dual_stack: "false"
     name: integration-test (${{ matrix.name }})
     steps:
@@ -208,6 +211,7 @@ jobs:
           kubectl logs -n istio-system -l app=istiod --tail=200           > /tmp/istio-debug/istiod-logs.txt    2>&1 || true
           kubectl logs -n istio-system -l k8s-app=istio-cni-node --tail=200 > /tmp/istio-debug/cni-logs.txt    2>&1 || true
           kubectl logs -n istio-system -l app=ztunnel --tail=200          > /tmp/istio-debug/ztunnel-logs.txt   2>&1 || true
+          kubectl logs -n istio-system job/istio-patch-pss --tail=200      > /tmp/istio-debug/patch-pss-logs.txt 2>&1 || true
 
       - name: Upload debug bundle
         if: failure()

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ helm upgrade --install qubership-istio helm-templates/qubership-istio \
 
 Install in `istio-system` only — one instance per cluster.
 
+If the cluster enforces Pod Security Admission on `istio-system`, add `--set ENABLE_PRIVILEGED_PSS=true` so a pre-install hook labels the namespace `pod-security.kubernetes.io/enforce=privileged` — ambient mode's `istio-cni` and `ztunnel` DaemonSets need privileged pods. See [Pod Security Admission](docs/public/installation.md#pod-security-admission).
+
 **Enroll a namespace into the ambient mesh:**
 
 ```bash
@@ -42,6 +44,7 @@ Restart existing workloads after labeling.
 | `global.profile` | `ambient` | Mesh profile |
 | `global.hub` / `tag` | — | Image registry override |
 | `MONITORING_ENABLED` | `true` | Deploy ServiceMonitor, PodMonitor, GrafanaDashboards |
+| `ENABLE_PRIVILEGED_PSS` | `false` | Pre-install hook Job labels the release namespace `pod-security.kubernetes.io/enforce=privileged` (needed on Pod-Security-Admission clusters) |
 | `monitoring.scrapeInterval` | `15s` | Prometheus scrape interval |
 | `istiod.*`, `ztunnel.*`, `cni.*` | see `values.yaml` | Pass any upstream Istio values under the subchart key |
 

--- a/docs/public/installation.md
+++ b/docs/public/installation.md
@@ -8,6 +8,7 @@
   - [qubership-istio](#qubership-istio)
 - [Installation](#installation)
   - [Before you begin](#before-you-begin)
+    - [Pod Security Admission](#pod-security-admission)
   - [On-prem](#on-prem)
 - [Upgrade](#upgrade)
 - [Rollback](#rollback)
@@ -71,6 +72,12 @@ Recommended for deployments with high workload and large amount of data.
 |Parameter          |Type   |Mandatory|Default value|Description                                                                                 |
 |-------------------|-------|---------|-------------|--------------------------------------------------------------------------------------------|
 |MONITORING_ENABLED |boolean|no       |true         |Flag to install custom resources (PodMonitor and grafana dashboard) for prometheus monitoring|
+|ENABLE_PRIVILEGED_PSS|boolean|no     |false        |Run a pre-install/pre-upgrade hook Job that labels the release namespace `pod-security.kubernetes.io/enforce=privileged`. Required on clusters where Pod Security Admission enforces `baseline` or `restricted` on `istio-system` — see [Pod Security Admission](#pod-security-admission)|
+|patchPss.image     |string |no       |`ghcr.io/netcracker/qubership-docker-kubectl:main`|kubectl image used by the PSS patch Job. Not an Istio image, so it is not derived from `global.hub`|
+|patchPss.imagePullPolicy|string|no   |IfNotPresent |Image pull policy for the PSS patch Job                                                     |
+|patchPss.resources |object |no       |75m/75Mi requests, 150m/150Mi limits|Resources for the PSS patch Job container                                          |
+|patchPss.podSecurityContext|object|no|`runAsNonRoot: true`, `runAsUser: 1001`, `seccompProfile.type: RuntimeDefault`|Pod security context of the PSS patch Job. Must stay compliant with the policy currently enforced on the namespace, otherwise the Job cannot be admitted in order to relax it|
+|patchPss.containerSecurityContext|object|no|no privilege escalation, drop `ALL`, read-only root filesystem|Container security context of the PSS patch Job|
 
 In Helm values you can provide any configuration parameters supported by corresponding vanilla Istio helm chart, e.g. to set default connectTimeout for `istiod`:
 ```yaml
@@ -84,6 +91,32 @@ qubership-istio: # root helm chart
 # Installation
 ## Before you begin
 Qubership Istio distro should always be installed into `istio-system` namespace. No other applications should be installed in this namespace. Only single instance of Qubership Istio must be installed on kubernetes cluster.
+
+### Pod Security Admission
+Istio Ambient Mesh requires privileged pods: the `istio-cni` DaemonSet needs `hostNetwork` together with the `NET_ADMIN` and `SYS_ADMIN` capabilities, and `ztunnel` needs the same. If Pod Security Admission enforces `baseline` or `restricted` on `istio-system`, both DaemonSets are created as objects but their pods are rejected at admission. The symptom is misleading: the DaemonSets exist with `DESIRED > 0` and `READY 0`, and the rejection is visible only in events:
+
+```bash
+kubectl get events -n istio-system --field-selector reason=FailedCreate
+```
+
+The namespace must therefore carry `pod-security.kubernetes.io/enforce=privileged`. There are two ways to arrange that:
+
+1. A cluster administrator applies the label out-of-band before the installation:
+
+   ```bash
+   kubectl label --overwrite namespace istio-system \
+     pod-security.kubernetes.io/enforce=privileged
+   ```
+
+2. Install with `ENABLE_PRIVILEGED_PSS=true`, which does the same from a `pre-install`/`pre-upgrade` hook Job before any Istio component is applied:
+
+   ```bash
+   helm upgrade --install qubership-istio <chart> \
+     --namespace istio-system --create-namespace \
+     --set ENABLE_PRIVILEGED_PSS=true
+   ```
+
+The option is disabled by default, because it is a no-op on clusters without Pod Security Admission and because namespace security labels are usually owned by the cluster administrator. Note that the label is **not** removed by `helm uninstall`.
 
 ### Helm
 Install via Helm into `istio-system` namespace.

--- a/docs/public/installation.md
+++ b/docs/public/installation.md
@@ -8,7 +8,6 @@
   - [qubership-istio](#qubership-istio)
 - [Installation](#installation)
   - [Before you begin](#before-you-begin)
-    - [Pod Security Admission](#pod-security-admission)
   - [On-prem](#on-prem)
 - [Upgrade](#upgrade)
 - [Rollback](#rollback)
@@ -72,7 +71,7 @@ Recommended for deployments with high workload and large amount of data.
 |Parameter          |Type   |Mandatory|Default value|Description                                                                                 |
 |-------------------|-------|---------|-------------|--------------------------------------------------------------------------------------------|
 |MONITORING_ENABLED |boolean|no       |true         |Flag to install custom resources (PodMonitor and grafana dashboard) for prometheus monitoring|
-|ENABLE_PRIVILEGED_PSS|boolean|no     |false        |Run a pre-install/pre-upgrade hook Job that labels the release namespace `pod-security.kubernetes.io/enforce=privileged`. Required on clusters where Pod Security Admission enforces `baseline` or `restricted` on `istio-system` — see [Pod Security Admission](#pod-security-admission)|
+|ENABLE_PRIVILEGED_PSS|boolean|no     |false        |Label the release namespace `pod-security.kubernetes.io/enforce=privileged` from a pre-install/pre-upgrade hook Job, for clusters where Pod Security Admission would otherwise reject the Ambient Mesh pods. Needs `get` and `patch` on the namespace|
 |patchPss.image     |string |no       |`ghcr.io/netcracker/qubership-docker-kubectl:main`|kubectl image used by the PSS patch Job. Not an Istio image, so it is not derived from `global.hub`|
 |patchPss.imagePullPolicy|string|no   |IfNotPresent |Image pull policy for the PSS patch Job                                                     |
 |patchPss.resources |object |no       |75m/75Mi requests, 150m/150Mi limits|Resources for the PSS patch Job container                                          |
@@ -91,43 +90,6 @@ qubership-istio: # root helm chart
 # Installation
 ## Before you begin
 Qubership Istio distro should always be installed into `istio-system` namespace. No other applications should be installed in this namespace. Only single instance of Qubership Istio must be installed on kubernetes cluster.
-
-### Pod Security Admission
-Istio Ambient Mesh requires privileged pods: the `istio-cni` DaemonSet needs `hostNetwork` together with the `NET_ADMIN` and `SYS_ADMIN` capabilities, and `ztunnel` needs the same. If Pod Security Admission enforces `baseline` or `restricted` on `istio-system`, both DaemonSets are created as objects but their pods are rejected at admission. The symptom is misleading: the DaemonSets exist with `DESIRED > 0` and `READY 0`, and the rejection is visible only in events:
-
-```bash
-kubectl get events -n istio-system --field-selector reason=FailedCreate
-```
-
-The namespace must therefore carry `pod-security.kubernetes.io/enforce=privileged`. There are two ways to arrange that:
-
-1. A cluster administrator applies the label out-of-band before the installation:
-
-   ```bash
-   kubectl label --overwrite namespace istio-system \
-     pod-security.kubernetes.io/enforce=privileged
-   ```
-
-2. Install with `ENABLE_PRIVILEGED_PSS=true`, which does the same from a `pre-install`/`pre-upgrade` hook Job before any Istio component is applied:
-
-   ```bash
-   helm upgrade --install qubership-istio <chart> \
-     --namespace istio-system --create-namespace \
-     --set ENABLE_PRIVILEGED_PSS=true
-   ```
-
-The option is disabled by default, because it is a no-op on clusters without Pod Security Admission and because namespace security labels are usually owned by the cluster administrator. Note that the label is **not** removed by `helm uninstall`.
-
-On a cluster with no access to the public internet the image has to be overridden together with the switch, because `patchPss.image` defaults to `ghcr.io`. A released tag is worth preferring over `main`, whose content changes under the same name:
-
-```bash
-helm upgrade --install qubership-istio <chart> \
-  --namespace istio-system --create-namespace \
-  --set ENABLE_PRIVILEGED_PSS=true \
-  --set patchPss.image=<registry>/netcracker/qubership-docker-kubectl:<tag>
-```
-
-An unreachable image here costs more than the label. The Job is a `pre-install`/`pre-upgrade` hook, so Helm waits for it before applying anything else: the release fails with no Istio component installed at all, not with Istio installed and the namespace unlabelled. Where the deploy identity cannot be granted `get` and `patch` on the namespace, use the first option instead and leave `ENABLE_PRIVILEGED_PSS` off.
 
 ### Helm
 Install via Helm into `istio-system` namespace.

--- a/docs/public/installation.md
+++ b/docs/public/installation.md
@@ -2,6 +2,7 @@
 - [Prerequisites](#prerequisites)
   - [Common](#common)
   - [Kubernetes](#kubernetes)
+    - [Pod Security Admission](#pod-security-admission)
 - [Best practices and recommendations](#best-practices-and-recommendations)
   - [HWE](#hwe)
 - [Parameters](#parameters)
@@ -33,6 +34,38 @@ Qubership Istio should be installed under the service account with cluster-admin
 Supported k8s versions: 1.31, 1.32, 1.33, 1.34, 1.35.
 
 Kubernetes Gateway API CRDs are not included into this distro - they should be preinstalled on the cluster.
+
+### Pod Security Admission
+Istio Ambient Mesh requires privileged pods: `istio-cni` and `ztunnel` need `hostNetwork` together with the `NET_ADMIN` and `SYS_ADMIN` capabilities.
+If Pod Security Admission enforces `baseline` or `restricted` on `istio-system`, both DaemonSets are created but their pods are rejected at admission.
+To be able to install the distro you need to provide `privileged` policy to `istio-system` namespace as prerequisite step.
+
+It can be performed with the following command:
+
+```bash
+kubectl label --overwrite ns istio-system pod-security.kubernetes.io/enforce=privileged
+```
+
+This command can be executed automatically with property `ENABLE_PRIVILEGED_PSS: true` in deployment parameters.
+It requires the following cluster rights for deployment user:
+
+```yaml
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "patch"]
+    resourceNames:
+    - istio-system
+```
+
+The property runs a pre-install hook Job with the `kubectl` image from `patchPss.image`.
+Override it when the default registry is not reachable from the cluster:
+
+```yaml
+qubership-istio:
+  patchPss:
+    image: <registry>/qubership-docker-kubectl:<tag>
+```
+
 
 # Best practices and recommendations
 ## HWE

--- a/docs/public/installation.md
+++ b/docs/public/installation.md
@@ -118,6 +118,17 @@ The namespace must therefore carry `pod-security.kubernetes.io/enforce=privilege
 
 The option is disabled by default, because it is a no-op on clusters without Pod Security Admission and because namespace security labels are usually owned by the cluster administrator. Note that the label is **not** removed by `helm uninstall`.
 
+On a cluster with no access to the public internet the image has to be overridden together with the switch, because `patchPss.image` defaults to `ghcr.io`. A released tag is worth preferring over `main`, whose content changes under the same name:
+
+```bash
+helm upgrade --install qubership-istio <chart> \
+  --namespace istio-system --create-namespace \
+  --set ENABLE_PRIVILEGED_PSS=true \
+  --set patchPss.image=<registry>/netcracker/qubership-docker-kubectl:<tag>
+```
+
+An unreachable image here costs more than the label. The Job is a `pre-install`/`pre-upgrade` hook, so Helm waits for it before applying anything else: the release fails with no Istio component installed at all, not with Istio installed and the namespace unlabelled. Where the deploy identity cannot be granted `get` and `patch` on the namespace, use the first option instead and leave `ENABLE_PRIVILEGED_PSS` off.
+
 ### Helm
 Install via Helm into `istio-system` namespace.
 

--- a/helm-templates/qubership-istio/templates/NOTES.txt
+++ b/helm-templates/qubership-istio/templates/NOTES.txt
@@ -30,3 +30,26 @@ sub-chart name in your values file. For example:
       requests:
         cpu: 500m
         memory: 512Mi
+
+Pod Security Standards:
+{{- if .Values.ENABLE_PRIVILEGED_PSS }}
+
+  A pre-install/pre-upgrade hook labelled namespace {{ .Release.Namespace }} with
+  pod-security.kubernetes.io/enforce=privileged. The label is left in place by
+  `helm uninstall`; remove it manually if the namespace is reused.
+{{- else }}
+
+  Istio ambient requires privileged pods (istio-cni and ztunnel). If this cluster
+  enforces Pod Security Admission on {{ .Release.Namespace }}, those DaemonSets
+  will report 0 ready pods and the rejection appears only in events:
+
+    kubectl get events -n {{ .Release.Namespace }} --field-selector reason=FailedCreate
+
+  Fix it either out-of-band:
+
+    kubectl label --overwrite namespace {{ .Release.Namespace }} \
+      pod-security.kubernetes.io/enforce=privileged
+
+  or by re-running the install with --set ENABLE_PRIVILEGED_PSS=true, which does
+  the same from a pre-install hook.
+{{- end }}

--- a/helm-templates/qubership-istio/templates/PatchPss.yaml
+++ b/helm-templates/qubership-istio/templates/PatchPss.yaml
@@ -15,10 +15,14 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
-{{- /* Undefined at parent level unless the operator sets it; an empty list is rejected. */}}
+{{- /* Istio convention: a list of bare secret names, not LocalObjectReference objects, so
+     each one is wrapped here - the core/v1 API rejects a plain string at decode. `with`
+     skips both an unset value and an empty list, which the API rejects too. */}}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{- toYaml . | nindent 2 }}
+{{- range . }}
+  - name: {{ . }}
+{{- end }}
 {{- end }}
 ---
 # A namespaced Role can authorize the namespace object itself: the apiserver sets the

--- a/helm-templates/qubership-istio/templates/PatchPss.yaml
+++ b/helm-templates/qubership-istio/templates/PatchPss.yaml
@@ -1,0 +1,174 @@
+{{- if .Values.ENABLE_PRIVILEGED_PSS }}
+---
+# Identity for the patch-pss Job. Weight 0 so it exists before the Job (weight 1).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-patch-pss
+  labels:
+    app: qubership-istio
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: istio-patch-pss
+    app.kubernetes.io/part-of: qubership-istio
+    app.kubernetes.io/component: pss-patch-resources
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+{{- /* Undefined at parent level unless the operator sets it; an empty list is rejected. */}}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+---
+# A namespaced Role can authorize the namespace object itself: the apiserver sets the
+# request's namespace attribute to <ns> for /api/v1/namespaces/<ns>.
+# `kubectl label ns` needs only get+patch. Never add list/watch — resourceNames does
+# not restrict collection verbs, so it would widen this to every namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: istio-patch-pss
+  labels:
+    app: qubership-istio
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: istio-patch-pss
+    app.kubernetes.io/part-of: qubership-istio
+    app.kubernetes.io/component: pss-patch-resources
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    resourceNames:
+      - {{ .Release.Namespace }}
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istio-patch-pss
+  labels:
+    app: qubership-istio
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: istio-patch-pss
+    app.kubernetes.io/part-of: qubership-istio
+    app.kubernetes.io/component: pss-patch-resources
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: istio-patch-pss
+subjects:
+  - kind: ServiceAccount
+    name: istio-patch-pss
+    # namespace omitted: defaults to the binding's own namespace.
+---
+# Istio ambient requires privileged pods (istio-cni: hostNetwork + NET_ADMIN/SYS_ADMIN;
+# ztunnel: the same). Under Pod Security Admission both DaemonSets are accepted as
+# objects but their pods are rejected, leaving the mesh with no data plane.
+# This pre-install/pre-upgrade hook labels the release namespace enforce=privileged
+# before any Istio manifest is applied. Idempotent: no write when already correct.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-patch-pss
+  labels:
+    app: qubership-istio
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: istio-patch-pss
+    app.kubernetes.io/part-of: qubership-istio
+    app.kubernetes.io/component: pss-patch-resources
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    # 1 > the RBAC resources' 0, so the SA/Role/RoleBinding already exist.
+    "helm.sh/hook-weight": "1"
+    # before-hook-creation is required: Job pod templates are immutable, so a
+    # surviving same-named Job breaks the second upgrade. hook-failed is omitted
+    # on purpose so failed Jobs and their logs survive for triage.
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  # Retries count against helm's --timeout, and both realistic failures
+  # (RBAC denied, admission policy forbids the label) are permanent.
+  backoffLimit: 2
+  template:
+    metadata:
+      name: istio-patch-pss
+      labels:
+        app: qubership-istio
+        release: {{ .Release.Name }}
+        app.kubernetes.io/name: istio-patch-pss
+        app.kubernetes.io/part-of: qubership-istio
+        app.kubernetes.io/component: pss-patch-resources
+    spec:
+      restartPolicy: Never
+      serviceAccountName: istio-patch-pss
+      # Must stay restricted-compliant: this pod has to be admitted under the very
+      # policy it exists to relax.
+      securityContext:
+        {{- toYaml .Values.patchPss.podSecurityContext | nindent 8 }}
+      containers:
+        - name: patch-pss
+          image: {{ .Values.patchPss.image | quote }}
+          imagePullPolicy: {{ .Values.patchPss.imagePullPolicy }}
+          env:
+            - name: NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            # Image sets HOME=/ and the rootfs is read-only; point kubectl's cache at /tmp.
+            - name: HOME
+              value: /tmp
+            - name: KUBECACHEDIR
+              value: /tmp/.kube/cache
+          # The image's ENTRYPOINT is kubectl, so command must be a shell.
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+
+              LABEL_KEY="pod-security.kubernetes.io/enforce"
+              LABEL_VALUE="privileged"
+
+              if [ -z "${NAMESPACE}" ]; then
+                echo "ERROR: NAMESPACE is empty; refusing to patch an unknown namespace"
+                exit 121
+              fi
+
+              # An absent label yields an empty string and exit 0.
+              current="$(kubectl get namespace "${NAMESPACE}" \
+                -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}')"
+              echo "Namespace ${NAMESPACE}: current ${LABEL_KEY}=${current:-<unset>}"
+
+              if [ "${current}" = "${LABEL_VALUE}" ]; then
+                echo "OK: ${LABEL_KEY} is already '${LABEL_VALUE}'; nothing to do"
+                exit 0
+              fi
+
+              if kubectl label --overwrite namespace "${NAMESPACE}" "${LABEL_KEY}=${LABEL_VALUE}"; then
+                echo "OK: namespace ${NAMESPACE} labelled ${LABEL_KEY}=${LABEL_VALUE}"
+              else
+                echo "ERROR: failed to label namespace ${NAMESPACE} with ${LABEL_KEY}=${LABEL_VALUE}"
+                echo "Istio ambient (istio-cni, ztunnel) needs privileged pods and will be"
+                echo "rejected by Pod Security Admission until this label is set. Grant the"
+                echo "deploy identity get+patch on the namespace, apply the label out-of-band,"
+                echo "or set ENABLE_PRIVILEGED_PSS=false."
+                exit 1
+              fi
+          resources:
+            {{- toYaml .Values.patchPss.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.patchPss.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        # Only so readOnlyRootFilesystem and HOME=/tmp can coexist.
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/helm-templates/qubership-istio/values.yaml
+++ b/helm-templates/qubership-istio/values.yaml
@@ -159,3 +159,49 @@ ztunnel:
 MONITORING_ENABLED: true
 monitoring:
   scrapeInterval: 15s
+
+# ---------------------------------------------------------------------------
+# pre-deploy — namespace Pod Security Standards patch
+# ---------------------------------------------------------------------------
+# Istio ambient requires privileged pods (istio-cni needs hostNetwork plus
+# NET_ADMIN/SYS_ADMIN; ztunnel needs the same). Where Pod Security Admission
+# enforces "baseline" or "restricted" on this namespace, those DaemonSets are
+# accepted as objects but their pods are rejected, leaving no data plane.
+#
+# When enabled, a pre-install/pre-upgrade hook Job labels the release namespace
+# pod-security.kubernetes.io/enforce=privileged before Istio is installed.
+# Opt-in: it is a no-op without PSA, and namespace security labels are usually
+# owned by the cluster administrator. The label is NOT removed on uninstall.
+ENABLE_PRIVILEGED_PSS: false
+
+patchPss:
+  # kubectl image for the patch Job. Not derived from global.hub, which is the
+  # *Istio* image hub (<hub>/pilot:<tag>) — this is not an Istio image.
+  image: ghcr.io/netcracker/qubership-docker-kubectl:main
+  imagePullPolicy: IfNotPresent
+
+  resources:
+    requests:
+      cpu: 75m
+      memory: 75Mi
+    limits:
+      cpu: 150m
+      memory: 150Mi
+
+  # Must stay restricted-compliant: if the namespace already enforces
+  # "restricted", a non-compliant pod is rejected and the label can never be
+  # fixed. runAsUser must stay non-zero — runAsNonRoot alone is re-checked by the
+  # kubelet against the image's user. 1001 matches the kubectl image's USER.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Container-level only — PSS "restricted" does not inherit these from the pod.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL

--- a/tests/patch-pss/test.sh
+++ b/tests/patch-pss/test.sh
@@ -23,7 +23,10 @@ ORIGINAL_LABEL="$(read_label)"
 
 # Always hand the namespace back as we found it: a leftover enforce=restricted
 # would make every later pod creation in istio-system fail.
+PREINSTALL_NS="patch-pss-preinstall"
+
 cleanup() {
+  kubectl delete namespace "${PREINSTALL_NS}" --ignore-not-found --wait=false || true
   if [ -z "${ORIGINAL_LABEL}" ]; then
     kubectl label namespace "${ISTIO_NAMESPACE}" "${LABEL_KEY}-" || true
   else
@@ -131,5 +134,46 @@ if [ "$(read_label)" != "privileged" ]; then
   fail "label changed on the idempotent re-run"
 fi
 echo "OK: second run is a no-op"
+
+# --- 6. Install path: the Job is admitted by a namespace that enforced
+#        "restricted" from the moment it was created ---
+# Checks 3-5 exercise the pre-upgrade branch, where the namespace is relaxed
+# again by an earlier release and the label is put back by hand. The install
+# branch is the harder one and the one an air-gapped operator hits first: the
+# namespace is born "restricted", nothing has run in it yet, and the hook has to
+# get its own pod past the policy it exists to relax. Rendering the hook on its
+# own keeps this to one namespace and does not disturb the release under test.
+kubectl create namespace "${PREINSTALL_NS}"
+kubectl label --overwrite namespace "${PREINSTALL_NS}" "${LABEL_KEY}=restricted"
+
+helm template "${HELM_RELEASE}" "${HELM_CHART_PATH}" \
+  --namespace "${PREINSTALL_NS}" \
+  --set MONITORING_ENABLED=false \
+  --set ENABLE_PRIVILEGED_PSS=true \
+  --show-only templates/PatchPss.yaml > "${RENDER_DIR}/preinstall.yaml"
+
+# Without --validate the apiserver still runs admission, which is the point here:
+# a non-compliant pod template is rejected when the Job creates its pod.
+kubectl apply -n "${PREINSTALL_NS}" -f "${RENDER_DIR}/preinstall.yaml"
+
+if ! kubectl wait --for=condition=complete job/istio-patch-pss \
+    -n "${PREINSTALL_NS}" --timeout=120s; then
+  echo "--- Job ---"
+  kubectl describe job/istio-patch-pss -n "${PREINSTALL_NS}" || true
+  echo "--- pods ---"
+  kubectl get pods -n "${PREINSTALL_NS}" -o wide || true
+  echo "--- events ---"
+  kubectl get events -n "${PREINSTALL_NS}" --sort-by=.lastTimestamp || true
+  fail "patch-pss Job did not complete in a namespace that enforces restricted"
+fi
+
+PREINSTALL_LABEL="$(kubectl get namespace "${PREINSTALL_NS}" \
+  -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}')"
+if [ "${PREINSTALL_LABEL}" != "privileged" ]; then
+  fail "expected ${LABEL_KEY}=privileged on ${PREINSTALL_NS}, got '${PREINSTALL_LABEL}'"
+fi
+echo "OK: hook admitted itself into a restricted namespace and relabelled it on the install path"
+
+kubectl delete namespace "${PREINSTALL_NS}" --wait=false
 
 echo "All patch-pss checks passed"

--- a/tests/patch-pss/test.sh
+++ b/tests/patch-pss/test.sh
@@ -5,6 +5,8 @@ set -eux
 #   - nothing is rendered while ENABLE_PRIVILEGED_PSS is off (the default);
 #   - the rendered Job is PSS "restricted"-compliant and the Role is scoped to
 #     this namespace by resourceNames;
+#   - global.imagePullSecrets, an Istio-convention list of bare names, reaches the
+#     ServiceAccount in the shape the core/v1 API accepts;
 #   - on a namespace that really enforces "restricted", the hook admits its own
 #     pod and flips the label to privileged (the chicken-and-egg guarantee, and
 #     the only check that cannot be made from rendered YAML);
@@ -58,6 +60,34 @@ for kind in ServiceAccount Role RoleBinding Job; do
   fi
 done
 echo "OK: all four patch-pss resources are rendered"
+
+# --- 2a. imagePullSecrets: Istio passes bare names, the API wants objects ---
+# global.imagePullSecrets is an Istio convention and holds plain strings, while
+# ServiceAccount.imagePullSecrets is []LocalObjectReference. Emitting the list
+# as-is renders valid YAML that the apiserver rejects at decode, so the shape is
+# checked here and the decode itself by a server dry-run.
+helm template "${HELM_RELEASE}" "${HELM_CHART_PATH}" \
+  --namespace "${ISTIO_NAMESPACE}" \
+  --set MONITORING_ENABLED=false \
+  --set ENABLE_PRIVILEGED_PSS=true \
+  --set "global.imagePullSecrets={first-secret,second-secret}" \
+  --show-only templates/PatchPss.yaml > "${RENDER_DIR}/pull-secrets.yaml"
+
+PULL_SECRET_NAMES="$(yq e -N \
+  'select(.kind == "ServiceAccount") | .imagePullSecrets[].name' \
+  "${RENDER_DIR}/pull-secrets.yaml" | tr '\n' ',')"
+if [ "${PULL_SECRET_NAMES}" != "first-secret,second-secret," ]; then
+  fail "expected imagePullSecrets named first-secret,second-secret, got '${PULL_SECRET_NAMES}'"
+fi
+
+kubectl apply --dry-run=server -f "${RENDER_DIR}/pull-secrets.yaml" \
+  || fail "the apiserver refused the rendered patch-pss manifests"
+
+# Unset stays unset: an empty imagePullSecrets list is rejected as well.
+if grep -q "imagePullSecrets" "${RENDER_DIR}/on.yaml"; then
+  fail "imagePullSecrets rendered although global.imagePullSecrets is not set"
+fi
+echo "OK: imagePullSecrets are named references, and absent when unset"
 
 JOB="$(yq e -N 'select(.kind == "Job" and .metadata.name == "istio-patch-pss")' "${RENDER_DIR}/on.yaml")"
 if [ "$(echo "${JOB}" | yq e '.spec.template.spec.securityContext.runAsNonRoot')" != "true" ]; then

--- a/tests/patch-pss/test.sh
+++ b/tests/patch-pss/test.sh
@@ -83,8 +83,14 @@ fi
 kubectl apply --dry-run=server -f "${RENDER_DIR}/pull-secrets.yaml" \
   || fail "the apiserver refused the rendered patch-pss manifests"
 
-# Unset stays unset: an empty imagePullSecrets list is rejected as well.
-if grep -q "imagePullSecrets" "${RENDER_DIR}/on.yaml"; then
+# Unset stays unset: an empty imagePullSecrets list is rejected as well. Rendered on
+# its own, because the full chart carries the word in Istio's own injector template.
+helm template "${HELM_RELEASE}" "${HELM_CHART_PATH}" \
+  --namespace "${ISTIO_NAMESPACE}" \
+  --set MONITORING_ENABLED=false \
+  --set ENABLE_PRIVILEGED_PSS=true \
+  --show-only templates/PatchPss.yaml > "${RENDER_DIR}/no-pull-secrets.yaml"
+if grep -q "imagePullSecrets" "${RENDER_DIR}/no-pull-secrets.yaml"; then
   fail "imagePullSecrets rendered although global.imagePullSecrets is not set"
 fi
 echo "OK: imagePullSecrets are named references, and absent when unset"

--- a/tests/patch-pss/test.sh
+++ b/tests/patch-pss/test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -eux
+
+# Verifies the pre-deploy Pod Security Standards patch (templates/PatchPss.yaml):
+#   - nothing is rendered while ENABLE_PRIVILEGED_PSS is off (the default);
+#   - the rendered Job is PSS "restricted"-compliant and the Role is scoped to
+#     this namespace by resourceNames;
+#   - on a namespace that really enforces "restricted", the hook admits its own
+#     pod and flips the label to privileged (the chicken-and-egg guarantee, and
+#     the only check that cannot be made from rendered YAML);
+#   - hook resources are cleaned up by hook-delete-policy;
+#   - a second run is a no-op and still succeeds.
+
+LABEL_KEY="pod-security.kubernetes.io/enforce"
+RENDER_DIR="$(mktemp -d)"
+
+read_label() {
+  kubectl get namespace "${ISTIO_NAMESPACE}" \
+    -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}'
+}
+
+ORIGINAL_LABEL="$(read_label)"
+
+# Always hand the namespace back as we found it: a leftover enforce=restricted
+# would make every later pod creation in istio-system fail.
+cleanup() {
+  if [ -z "${ORIGINAL_LABEL}" ]; then
+    kubectl label namespace "${ISTIO_NAMESPACE}" "${LABEL_KEY}-" || true
+  else
+    kubectl label --overwrite namespace "${ISTIO_NAMESPACE}" "${LABEL_KEY}=${ORIGINAL_LABEL}" || true
+  fi
+  rm -rf "${RENDER_DIR}"
+}
+trap cleanup EXIT
+
+# --- 1. Off by default: no patch-pss resources rendered ---
+helm template "${HELM_RELEASE}" "${HELM_CHART_PATH}" \
+  --namespace "${ISTIO_NAMESPACE}" \
+  --set MONITORING_ENABLED=false > "${RENDER_DIR}/off.yaml"
+if grep -q "istio-patch-pss" "${RENDER_DIR}/off.yaml"; then
+  fail "patch-pss resources rendered although ENABLE_PRIVILEGED_PSS is off"
+fi
+echo "OK: no patch-pss resources rendered by default"
+
+# --- 2. Rendered manifests: restricted-compliant Job, namespace-scoped Role ---
+helm template "${HELM_RELEASE}" "${HELM_CHART_PATH}" \
+  --namespace "${ISTIO_NAMESPACE}" \
+  --set MONITORING_ENABLED=false \
+  --set ENABLE_PRIVILEGED_PSS=true > "${RENDER_DIR}/on.yaml"
+
+for kind in ServiceAccount Role RoleBinding Job; do
+  if ! yq e -N "select(.kind == \"${kind}\" and .metadata.name == \"istio-patch-pss\")" \
+      "${RENDER_DIR}/on.yaml" | grep -q .; then
+    fail "${kind}/istio-patch-pss missing from the rendered chart"
+  fi
+done
+echo "OK: all four patch-pss resources are rendered"
+
+JOB="$(yq e -N 'select(.kind == "Job" and .metadata.name == "istio-patch-pss")' "${RENDER_DIR}/on.yaml")"
+if [ "$(echo "${JOB}" | yq e '.spec.template.spec.securityContext.runAsNonRoot')" != "true" ]; then
+  fail "patch-pss pod is not runAsNonRoot; it would be rejected by PSS restricted"
+fi
+if [ "$(echo "${JOB}" | yq e '.spec.template.spec.securityContext.runAsUser')" = "0" ]; then
+  fail "patch-pss pod runAsUser must be non-zero"
+fi
+if [ "$(echo "${JOB}" | yq e '.spec.template.spec.securityContext.seccompProfile.type')" != "RuntimeDefault" ]; then
+  fail "patch-pss pod seccompProfile must be RuntimeDefault"
+fi
+if [ "$(echo "${JOB}" | yq e '.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation')" != "false" ]; then
+  fail "patch-pss container must set allowPrivilegeEscalation=false"
+fi
+if [ "$(echo "${JOB}" | yq e '.spec.template.spec.containers[0].securityContext.capabilities.drop[0]')" != "ALL" ]; then
+  fail "patch-pss container must drop ALL capabilities"
+fi
+echo "OK: rendered patch-pss Job satisfies PSS restricted"
+
+ROLE_NS="$(yq e -N 'select(.kind == "Role" and .metadata.name == "istio-patch-pss")
+  | .rules[0].resourceNames[0]' "${RENDER_DIR}/on.yaml")"
+if [ "${ROLE_NS}" != "${ISTIO_NAMESPACE}" ]; then
+  fail "Role resourceNames expected ${ISTIO_NAMESPACE}, got ${ROLE_NS}"
+fi
+echo "OK: Role is scoped to namespace ${ISTIO_NAMESPACE}"
+
+# --- 3. Live: the hook relaxes a namespace that really enforces "restricted" ---
+# PSA is evaluated at pod admission only, so labelling now cannot disturb the
+# already-running istio pods; the pre-upgrade hook restores privileged before the
+# upgrade applies any Istio manifest.
+kubectl label --overwrite namespace "${ISTIO_NAMESPACE}" "${LABEL_KEY}=restricted"
+if [ "$(read_label)" != "restricted" ]; then
+  fail "failed to stage ${LABEL_KEY}=restricted"
+fi
+
+# --force-conflicts: istiod takes SSA ownership of webhook fields, so upgrades
+# need it from the second one onwards (see templates/NOTES.txt).
+helm upgrade "${HELM_RELEASE}" "${HELM_CHART_PATH}" \
+  --namespace "${ISTIO_NAMESPACE}" \
+  --timeout 3m \
+  --wait \
+  --force-conflicts \
+  --reuse-values \
+  --set ENABLE_PRIVILEGED_PSS=true
+
+AFTER="$(read_label)"
+if [ "${AFTER}" != "privileged" ]; then
+  echo "ERROR: expected ${LABEL_KEY}=privileged after the hook, got '${AFTER}'"
+  kubectl get namespace "${ISTIO_NAMESPACE}" -o yaml
+  fail "patch-pss hook did not relabel the namespace"
+fi
+echo "OK: hook Job relabelled ${ISTIO_NAMESPACE} from restricted to privileged"
+
+# --- 4. Hook resources removed on success (hook-delete-policy) ---
+for res in job/istio-patch-pss \
+           serviceaccount/istio-patch-pss \
+           role.rbac.authorization.k8s.io/istio-patch-pss \
+           rolebinding.rbac.authorization.k8s.io/istio-patch-pss; do
+  if kubectl get "${res}" -n "${ISTIO_NAMESPACE}" >/dev/null 2>&1; then
+    fail "${res} still exists; hook-delete-policy hook-succeeded did not apply"
+  fi
+done
+echo "OK: hook resources cleaned up after success"
+
+# --- 5. Idempotency: re-running with the label already correct still succeeds ---
+helm upgrade "${HELM_RELEASE}" "${HELM_CHART_PATH}" \
+  --namespace "${ISTIO_NAMESPACE}" \
+  --timeout 3m \
+  --wait \
+  --force-conflicts \
+  --reuse-values \
+  --set ENABLE_PRIVILEGED_PSS=true
+if [ "$(read_label)" != "privileged" ]; then
+  fail "label changed on the idempotent re-run"
+fi
+echo "OK: second run is a no-op"
+
+echo "All patch-pss checks passed"


### PR DESCRIPTION
# Overview

A `pre-install`/`pre-upgrade` hook that labels the release namespace
`pod-security.kubernetes.io/enforce=privileged`, so Istio ambient can be installed on a cluster
whose Pod Security Admission would otherwise accept both DaemonSets as objects and reject their
pods, leaving the mesh with no data plane. Off by default (`ENABLE_PRIVILEGED_PSS`), because a
namespace's security labels usually belong to the cluster administrator, and because it is a no-op
where PSA is not enforced.

# Open questions — both resolved

**1. kubectl image delivery.** The chart keeps the `ghcr.io` default and exposes `patchPss.image`.
Getting that image into a particular distribution's artifact set stays outside this chart: only the
distribution knows its own registry, and hard-coding one here would break every other one.
`docs/public/installation.md` documents the override next to the switch that turns the hook on and
spells out the consequence that is easy to miss — the Job is a hook, so Helm waits for it before
applying anything else, and an image that cannot be pulled fails the **whole release** with no
Istio component installed at all, rather than leaving Istio up with the namespace unlabelled.

**2. podSecurityContext and containerSecurityContext.** The values as they stand are complete for
`restricted`; nothing further is needed.

| What `restricted` requires | Where it is set |
|---|---|
| `runAsNonRoot: true` | pod |
| non-zero `runAsUser` | pod — `1001`, pinned deliberately: `runAsNonRoot` alone is re-checked by the kubelet against the image's own `USER`, which would fail at container start instead of at admission |
| `seccompProfile.type: RuntimeDefault` | pod |
| `allowPrivilegeEscalation: false` | container |
| `capabilities.drop: ["ALL"]` | container |
| no `privileged`, no host namespaces, no `hostPath`, no unconfined AppArmor | not set anywhere in the Job |

`readOnlyRootFilesystem: true` goes beyond what `restricted` asks for. It is the reason the Job
mounts an `emptyDir` at `/tmp` and points `HOME` and `KUBECACHEDIR` there: the image sets `HOME=/`,
and kubectl needs somewhere to write its cache.

Both were verified on the **install** path, where the namespace enforces `restricted` from the
moment it is created and the hook has to get its own pod past the policy it exists to relax — see
the comment below for the run. `tests/patch-pss/test.sh` now covers that path, so CI keeps checking
it.

# How To Test
1. Put admission.yaml file:
```yaml
kind: AdmissionConfiguration
plugins:
- name: PodSecurity
  configuration:
    apiVersion: pod-security.admission.config.k8s.io/v1
    kind: PodSecurityConfiguration
    defaults:
      enforce: restricted
      enforce-version: latest
      audit: restricted
      audit-version: latest
      warn: restricted
      warn-version: latest
    exemptions:
      usernames: []
      runtimeClasses: []
      namespaces:
      - kube-system
```
2. Put k3d-config.yaml file:
```yaml
kind: Simple
metadata:
  name: ambient
servers: 1
agents: 0
volumes:
  - volume: /tmp/k3d-conf/admission.yaml:/etc/kubernetes/pki/admission.yaml
    nodeFilters:
      - server:*
options:
  k3s:
    extraArgs:
      - arg: --kube-apiserver-arg=admission-control-config-file=/etc/kubernetes/pki/admission.yaml
        nodeFilters:
          - server:*
```
3. Create cluster:
```sh
k3d cluster create ambient \
  --config k3d-config.yaml \
  --k3s-arg "--disable=traefik@server:*" \
  -p "80:80@loadbalancer" \
  -p "443:443@loadbalancer" \
  --agents 2
```
4. Create superadmin:
```sh
kubectl create clusterrolebinding superadmin \
  --clusterrole=cluster-admin \
  --user=superadmin
```
5. Deploy istio from sources:
```sh
helm dependency update ./helm-templates/qubership-istio/
```
```sh
helm upgrade --install qubership-istio ./helm-templates/qubership-istio/ --namespace istio-system --create-namespace --set MONITORING_ENABLED=false
```
ER: istio-cni and ztunnel pods created and work properly; warning regarding pss is shown during helm upgrade


